### PR TITLE
chore: build with GHC 9.6.7

### DIFF
--- a/snaplet-postgresql-simple.cabal
+++ b/snaplet-postgresql-simple.cabal
@@ -22,7 +22,8 @@ tested-with:
   GHC == 8.4.3,
   GHC == 8.6.4,
   GHC == 8.8.3,
-  GHC == 8.10.2
+  GHC == 8.10.2,
+  GHC == 9.6.7
 
 extra-source-files:
   LICENSE
@@ -53,19 +54,19 @@ Library
     Paths_snaplet_postgresql_simple
 
   build-depends:
-    base                       >= 4       && < 4.15,
-    bytestring                 >= 0.9.1   && < 0.11,
+    base                       >= 4       && < 4.19,
+    bytestring                 >= 0.9.1   && < 0.12,
     clientsession              >= 0.7.2   && < 0.10,
     configurator               >= 0.2     && < 0.4,
-    lens                       >= 3.7.6   && < 4.20,
+    lens                       >= 3.7.6   && < 6,
     lifted-base                >= 0.2     && < 0.3,
     monad-control              >= 1.0     && < 1.1,
-    mtl                        >= 2       && < 2.3,
-    postgresql-simple          >= 0.3     && < 0.7,
+    mtl                        >= 2       && < 2.4,
+    postgresql-simple          >= 0.3     && < 0.8,
     resource-pool              >= 0.2     && < 0.3,
     snap                       >= 1.0     && < 1.2,
-    text                       >= 0.11    && < 1.3,
-    transformers               >= 0.2     && < 0.6,
+    text                       >= 0.11    && < 3,
+    transformers               >= 0.2     && < 0.7,
     transformers-base          >= 0.4     && < 0.5,
     unordered-containers       >= 0.2     && < 0.3
 


### PR DESCRIPTION
It is questionable to tear the bounds on `lens` and  `text` all the way. Questionable but effective.